### PR TITLE
Add 允许设置下载文件名

### DIFF
--- a/src/AliyunOssAdapter.php
+++ b/src/AliyunOssAdapter.php
@@ -45,6 +45,7 @@ class AliyunOssAdapter extends AbstractAdapter
     protected static $mappingOptions = [
         'mimetype' => OssClient::OSS_CONTENT_TYPE,
         'size'     => OssClient::OSS_LENGTH,
+        'filename' => OssClient::OSS_CONTENT_DISPOSTION,
     ];
 
     /**


### PR DESCRIPTION
设置下载文件名是一件非常实用的功能，尤其是在对文件进行Hash存储的时候。